### PR TITLE
#1: making the height strictly 100% is preventing the scrollToTop

### DIFF
--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -17,7 +17,7 @@
 
 .header.scrolled {
   background-color: rgba(0, 0, 0, 0.95);
-  padding: 10px 0;
+  /* padding: 10px 0; */
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -7,12 +7,15 @@
 
 html,
 body {
-  min-height: 100%;
   overflow-x: hidden;
-  overscroll-behavior-y: contain; /* Prevent overscroll bounce */
-}
-
-body {
+    overscroll-behavior-y: none; 
+  }
+  html{
+    height:100%;
+  }
+  
+  body {
+    min-height: 100%;
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   background-color: #f0ede5;
   color: #333;

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -7,7 +7,7 @@
 
 html,
 body {
-  height: 100%;
+  min-height: 100%;
   overflow-x: hidden;
   overscroll-behavior-y: contain; /* Prevent overscroll bounce */
 }


### PR DESCRIPTION
Since body is an element of window, making it 100% would cause body to not flow out of window which is causing the scrollToTop functionality to not function as expected. 
So using min-height: 100% allows the body to overflow out of the window even though we can't see it and this is required for it to get scrolledTo top. 


**Note**: This is a react-friendly approacg but there is also another approach to achieve this that is in scrollToTop() instead of using window.scrollTo() use document.getElementByTagName("body")[0].scrollTo().

I tried both the methods and both of them work. 

Unit test after this change
Scrolling to bottom of home page and clicking About Us
<img width="1440" height="900" alt="Screenshot 2025-07-19 at 12 28 38 AM" src="https://github.com/user-attachments/assets/cc6683b1-51f6-4a36-8032-ff42b4f53858" />
About us page was smoothly scrolled to top. 
<img width="1439" height="899" alt="Screenshot 2025-07-19 at 12 28 48 AM" src="https://github.com/user-attachments/assets/3e23135d-592c-479a-ac5e-d4e31492f1e1" />