### PR TITLE
#7 fix - projects nav being span instead anchor caused styles to not get applied-bugFix

### DIFF
--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -130,7 +130,7 @@
   position: relative;
 }
 
-.nav__links li a {
+.nav__links li a, .nav-link-dropdown {
   font-family: "Poppins", sans-serif;
   font-weight: 500;
   color: white;


### PR DESCRIPTION
The project nav was span instead of anchor tag which caused the style to get get applied like the other nav elements and made it inconsistent. So the selector for projects nav along with the others.

- Mainly font-family and font-weight were different. 

After this chage: 

<img width="775" height="191" alt="Screenshot 2025-07-26 at 7 55 09 PM" src="https://github.com/user-attachments/assets/9ef6242f-c786-4efd-a80c-6fd5b75a63aa" />
